### PR TITLE
update cadvisor image repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       mode: global
 
   cadvisor:
-    image: google/cadvisor
+    image: gcr.io/cadvisor/cadvisor
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:rw


### PR DESCRIPTION
* Problem: Cadvisor is outdated and does not start up
* Solution: Use official google repo as described in [Cadvisor Readme](https://github.com/google/cadvisor)